### PR TITLE
Fix not working under Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ go get -tool github.com/hookenz/gotailwind/v4@latest
 
 Or a specific version of tailwindcss:
 ```
-go get github.com/hookenz/gotailwind/v4@v4.1.6
+go get -tool github.com/hookenz/gotailwind/v4@v4.1.7
 ```
 To run it:
 ```
@@ -32,7 +32,7 @@ binary that is downloaded and cached into a special folder.
 
 The tagged version corresponds to the tailwindcss binary.
 
-It has been tested under Linux.  It should work under mac and windows although I haven't tested it.
+It has been tested under Linux and Windows. It should work under mac although I haven't tested it.
 
 The version downloaded by this tool match the tailwindcss binary.
 In linux they are placed into the versioned directories beneath
@@ -42,7 +42,7 @@ In linux they are placed into the versioned directories beneath
 
 i.e.  
 ```
-~/.cache/gotailwind/v4.1.6/tailwindcss-linux-x64
+~/.cache/gotailwind/v4.1.7/tailwindcss-linux-x64
 ```
 
 # Contributing

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -81,7 +81,7 @@ func EnsureTailwindInstalled(version string) (string, error) {
 	if actualSum != expectedSum {
 		return "", fmt.Errorf("hash mismatch: expected %s, got %s", expectedSum, actualSum)
 	}
-	out.Close() // close before Chmod and Rename (Windows doesn't renaming opened file).
+	out.Close() // close before Chmod and Rename (Windows doesn't allow renaming opened file).
 
 	if err := os.Chmod(tmpFile, 0755); err != nil {
 		return "", err

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -81,6 +81,7 @@ func EnsureTailwindInstalled(version string) (string, error) {
 	if actualSum != expectedSum {
 		return "", fmt.Errorf("hash mismatch: expected %s, got %s", expectedSum, actualSum)
 	}
+	out.Close() // close before Chmod and Rename (Windows doesn't renaming opened file).
 
 	if err := os.Chmod(tmpFile, 0755); err != nil {
 		return "", err

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hookenz/gotailwind/v4/downloader"
 )
 
-const TaildwindCssVersion = "v4.1.5"
+const TaildwindCssVersion = "v4.1.7"
 
 func main() {
 	tailwindPath, err := downloader.EnsureTailwindInstalled(TaildwindCssVersion)


### PR DESCRIPTION
Windows doesn't allow renaming opened files, so before using Chmod and Rename you have to close tmpFile.
Also bumped TailwindCSS version to 4.1.7.