### PR TITLE
Add Alpine detection due to musl edge case

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -31,6 +31,13 @@ func EnsureTailwindInstalled(version string) (string, error) {
 		binaryName = "tailwindcss-linux-arm64"
 	case "linux-amd64":
 		binaryName = "tailwindcss-linux-x64"
+		if _, err := os.Stat("/etc/os-release"); err == nil {
+			if data, err := os.ReadFile("/etc/os-release"); err == nil {
+				if strings.Contains(string(data), "ID=alpine") {
+					binaryName += "-musl"
+				}
+			}
+		}
 	case "windows-amd64":
 		binaryName = "tailwindcss-windows-x64.exe"
 	default:

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -29,6 +29,13 @@ func EnsureTailwindInstalled(version string) (string, error) {
 		binaryName = "tailwindcss-macos-x64"
 	case "linux-arm64":
 		binaryName = "tailwindcss-linux-arm64"
+		if _, err := os.Stat("/etc/os-release"); err == nil {
+			if data, err := os.ReadFile("/etc/os-release"); err == nil {
+				if strings.Contains(string(data), "ID=alpine") {
+					binaryName += "-musl"
+				}
+			}
+		}
 	case "linux-amd64":
 		binaryName = "tailwindcss-linux-x64"
 		if _, err := os.Stat("/etc/os-release"); err == nil {


### PR DESCRIPTION
Earlier today I went down the classic rabbithole of "why won't my docker container build" when trying to automate some tailwind install/generation commands.
After sorting that out I came across this project (as I'd rather offload the installation overhead to something else), and as luck had it, I had just learned how to solve the exact same issue gotailwind was running into.

To test this PR throw the following into an existing go.mod set up to use gotailwind, and build a simple alpine image.
```
replace github.com/hookenz/gotailwind/v4 => github.com/p0t4t0sandwich/gotailwind/v4 v4.0.0-20250526235411-63fa87003b12
```

A quick example modified from [my own project](<https://github.com/NeuralNexusDev/neuralnexus-frontend/commit/aa3a23142cd1b257ab7971ce73fe9b5dbfee7265>):
```dockerfile
FROM golang:1.24.2-alpine AS build

WORKDIR /app
ENV CGO_ENABLED=0

RUN apk update && apk add --no-cache gcc make musl-dev

# Required for gotailwind override
RUN apk add --no-cache git

COPY go.mod go.sum ./
RUN go mod download

COPY . .

# Change this as necessary
RUN go tool gotailwind -i ./assets/css/input.css -o ./public/css/styles.css --minify
```

Please let me know if you have any questions/concerns!